### PR TITLE
Open pdf file with strict=False to prevent crash

### DIFF
--- a/src/menextract2pdf.py
+++ b/src/menextract2pdf.py
@@ -130,7 +130,7 @@ def add_annotation2pdf(inpdf, outpdf, annotations):
 
 def processpdf(fn, fn_out, annotations):
     try:
-        inpdf = PyPDF2.PdfFileReader(open(fn, 'rb'))
+        inpdf = PyPDF2.PdfFileReader(open(fn, 'rb'), strict=False)
         if inpdf.isEncrypted:
             # PyPDF2 seems to think some files are encrypted even
             # if they are not. We just ignore the encryption.
@@ -174,10 +174,3 @@ if __name__ == "__main__":
     if args.overwrite:
         OVERWRITE_PDFS = True
     mendeley2pdf(fn, dir_pdf)
-
-
-
-
-
-
-


### PR DESCRIPTION
Files such as the attachment will make the script fail and crash.
I do not know much about PDF files, but it seems to be due to it not following some standard.
The problem is described elsewhere, for other programs, such as [here](https://github.com/mstamy2/PyPDF2/issues/244), and [here](https://github.com/xhtml2pdf/xhtml2pdf/issues/333).
Opening the file with strict flag set to False fixes it, while still warning the user, as described [here](https://pythonhosted.org/PyPDF2/PdfFileReader.html).

[sample.pdf](https://github.com/cycomanic/Menextract2pdf/files/1188889/sample.pdf)